### PR TITLE
Update Gigapipe support status in backends overview documentation

### DIFF
--- a/docs/backends-overview.mdx
+++ b/docs/backends-overview.mdx
@@ -17,7 +17,7 @@ Odigos has destinations for many observability backends.
 | Datadog                 | Managed          |   ✅   |   ✅    |  ✅  |
 | Dynatrace               | Managed          |   ✅   |   ✅    |  ✅  |
 | Elasticsearch           | Self-Hosted      |   ✅   |         |  ✅  |
-| Gigapipe                | Managed          |   ✅   |         |      |
+| Gigapipe                | Managed          |   ✅   |   ✅    |  ✅  |
 | Google Cloud Monitoring | Managed          |   ✅   |   ✅    |      |
 | Google Cloud Storage    | Managed          |   ✅   |         |  ✅  |
 | Grafana Cloud           | Managed          |   ✅   |   ✅    |  ✅  |


### PR DESCRIPTION
This pull request includes a small change to the `docs/backends-overview.mdx` file. The change updates the status of Gigapipe to indicate full support for all observability features.

* [`docs/backends-overview.mdx`](diffhunk://#diff-26115b197a8b9dd8ee351f05b2cade47da5acd788d74b9f962a325d3e1b919a2L20-R20): Updated Gigapipe to show support for metrics, traces, and logs.